### PR TITLE
Revert "Add volume mounts to the base notebook template"

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -392,24 +392,10 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 	}
 
 	podSpec := &ss.Spec.Template.Spec
-	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
-		Name: "shm",
-		VolumeSource: corev1.VolumeSource{
-		EmptyDir: &corev1.EmptyDirVolumeSource{
-			Medium: corev1.StorageMediumMemory,
-			},
-		},
-	})
-	
-	
 	container := &podSpec.Containers[0]
 	if container.WorkingDir == "" {
 		container.WorkingDir = "/home/jovyan"
 	}
-	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name: "shm",
-		MountPath: "/dev/shm",
-	})
 	if container.Ports == nil {
 		container.Ports = []corev1.ContainerPort{
 			{


### PR DESCRIPTION
Revert "Add volume mounts to the base notebook template to change default shared memory limit for notebooks"

This reverts commit 41baf497ee3559890a6a5fa1f4ba4eb4a69c61a2.

Related-to: https://github.com/opendatahub-io/kubeflow/issues/145
JIRA: https://issues.redhat.com/browse/RHODS-10005
