### PR TITLE
Point the default patch image to the stable tag

### DIFF
--- a/components/notebook-controller/config/overlays/openshift/params.env
+++ b/components/notebook-controller/config/overlays/openshift/params.env
@@ -1,1 +1,1 @@
-odh-kf-notebook-controller-image=quay.io/opendatahub/kubeflow-notebook-controller:latest
+odh-kf-notebook-controller-image=quay.io/opendatahub/kubeflow-notebook-controller:stable

--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,1 +1,1 @@
-odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:latest
+odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:stable


### PR DESCRIPTION
As the latest tag points to the latest commit of v1.7 branch of the Opendatahub/kubeflow.
We would like to point the default image to the stable tag, so  we always have a stable changes available in notebook-controller. 

Point to the image of the branch:  https://github.com/opendatahub-io/kubeflow/tree/stable

- https://quay.io/repository/opendatahub/odh-notebook-controller?tab=tags
- https://quay.io/repository/opendatahub/kubeflow-notebook-controller