### PR TITLE
[rhoai-2.9] sync the fix for missing change of removing handler

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -248,11 +248,6 @@ func (w *NotebookWebhook) Handle(ctx context.Context, req admission.Request) adm
 		}
 	}
 
-	// Add the workbench label on notebook update
-	if req.Operation == admissionv1.Update {
-		AddWorkbenchLabel(notebook)
-	}
-
 	// Inject the OAuth proxy if the annotation is present
 	if OAuthInjectionIsEnabled(notebook.ObjectMeta) {
 		err = InjectOAuthProxy(notebook, w.OAuthConfig)


### PR DESCRIPTION
fix: remove handler for notebook update event
Related-to: https://github.com/opendatahub-io/kubeflow/pull/308