### PR TITLE
[rhoai-2.8.3][cherrypick] create configmap and mount for the first workbench in NS

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_controller_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_controller_test.go
@@ -178,6 +178,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 
 			By("By simulating the existence of odh-trusted-ca-bundle ConfigMap")
 			// Create a ConfigMap similar to odh-trusted-ca-bundle for simulation
+			workbenchTrustedCACertBundle := "workbench-trusted-ca-bundle"
 			trustedCACertBundle := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "odh-trusted-ca-bundle",
@@ -232,7 +233,7 @@ var _ = Describe("The Openshift Notebook controller", func() {
 				Name: "trusted-ca",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: trustedCACertBundle.Name},
+						LocalObjectReference: corev1.LocalObjectReference{Name: workbenchTrustedCACertBundle},
 						Optional:             pointer.Bool(true),
 						Items: []corev1.KeyToPath{
 							{

--- a/components/odh-notebook-controller/controllers/notebook_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_webhook.go
@@ -291,8 +291,24 @@ func CheckAndMountCACertBundle(ctx context.Context, cli client.Client, notebook 
 	workbenchConfigMap := &corev1.ConfigMap{}
 	err := cli.Get(ctx, client.ObjectKey{Namespace: notebook.Namespace, Name: workbenchConfigMapName}, workbenchConfigMap)
 	if err != nil {
-		log.Info("workbench-trusted-ca-bundle ConfigMap is not present, skipping mounting of certificates.")
-		return nil
+		log.Info("workbench-trusted-ca-bundle ConfigMap is not present, start creating it...")
+		// create the ConfigMap if it does not exist
+		workbenchConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workbenchConfigMapName,
+				Namespace: notebook.Namespace,
+				Labels:    map[string]string{"opendatahub.io/managed-by": "workbenches"},
+			},
+			Data: map[string]string{
+				"ca-bundle.crt": odhConfigMap.Data["ca-bundle.crt"],
+			},
+		}
+		err = cli.Create(ctx, workbenchConfigMap)
+		if err != nil {
+			log.Info("Failed to create workbench-trusted-ca-bundle ConfigMap")
+			return nil
+		}
+		log.Info("Created workbench-trusted-ca-bundle ConfigMap")
 	}
 
 	cm := workbenchConfigMap


### PR DESCRIPTION
[rhoai-2.8.3][cherrypick] Create configmap and mount for the first workbench in NS

Cherry-picked the commit for rhoai-2.8.3.
Related-to: https://issues.redhat.com/browse/RHOAIENG-6817