### PR TITLE
Updating go.opentelemetry.io/contrib

### DIFF
--- a/components/odh-notebook-controller/go.mod
+++ b/components/odh-notebook-controller/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/client-go v0.27.2
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 	sigs.k8s.io/controller-runtime v0.15.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
 )
 
 require (


### PR DESCRIPTION
Fixes for https://issues.redhat.com/browse/RHOAIENG-1263

Introduced through: k8s.io/component-base@v0.25.0, k8s.io/apiextensions-apiserver@v0.25.0 and others
sigs.k8s.io/controller-runtime@v0.13.0, github.com/manifestival/controller-runtime-client@v0.4.0
Fixed in: go.opentelemetry.io/contrib@0.44.0