### PR TITLE
Revert "[v1.9-branch] RHOAIENG-10827: feat(nbcs): update ose-oauth-pr…

### DIFF
--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: Always
           command:
             - /manager
-          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695"]
+          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46"]
           securityContext:
             allowPrivilegeEscalation: false
           ports:

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -35,10 +35,10 @@ import (
 const (
 	OAuthServicePort     = 443
 	OAuthServicePortName = "oauth-proxy"
-	// OAuthProxyImage uses sha256 manifest list digest value of v4.14 image for AMD64 as default to be compatible with imagePullPolicy: IfNotPresent, overridable
-	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64?image=66cefc14401df6ff4664ec43&architecture=amd64&container-tabs=overview
+	// OAuthProxyImage uses sha256 manifest list digest value of v4.8 image for AMD64 as default to be compatible with imagePullPolicy: IfNotPresent, overridable
+	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64?image=6306f12280cc9b3291272668&architecture=amd64&container-tabs=overview
 	// and kept in sync with the manifests here and in ClusterServiceVersion metadata of opendatahub operator
-	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695"
+	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46"
 )
 
 type OAuthConfig struct {


### PR DESCRIPTION
Revert "[v1.9-branch] [RHOAIENG-10827](https://issues.redhat.com//browse/RHOAIENG-10827): feat(nbcs): update ose-oauth-proxy image digest reference from 4.8 to the latest 4.14 version (#388)"

This reverts commit 99e70bf1c44d3cc2e07983ded45d1e37a4ed5f42.
JIRA: https://issues.redhat.com/browse/RHOAIENG-10827



Tested in following way:

- Created a stable-rhoai-2.13 deployment, started a workbench 
- Upgrade rhoai-2.14, as soon as the operator showed ready 
quickly change the DSC with following:

```
    workbenches:
      devFlags:
        manifests:
          - contextDir: components/odh-notebook-controller/config
            sourcePath: ''
            uri: >-
              https://github.com/harshad16/odh-kubeflow/archive/revert-oauth.tar.gz
```
- waited for all the controllers to start.
- create a new workbench 
- noticed no restart on older notebooks.
![Screenshot from 2024-10-15 10-55-25](https://github.com/user-attachments/assets/fa2b0d51-031d-43eb-b544-064b232b8df9)
