### PR TITLE
NO-JIRA: fix(gha): replace `oc` with `kubectl` in notebook_controller_integration_test.yaml

### DIFF
--- a/.github/workflows/notebook_controller_integration_test.yaml
+++ b/.github/workflows/notebook_controller_integration_test.yaml
@@ -89,7 +89,7 @@ jobs:
           export PR_NOTEBOOK_IMG=localhost/${{env.IMG}}:${{env.TAG}}
           kustomize edit set image ${CURRENT_NOTEBOOK_IMG}=${PR_NOTEBOOK_IMG}
 
-          cat <<EOF | oc apply -f -
+          cat <<EOF | kubectl apply -f -
           ---
           apiVersion: v1
           kind: ConfigMap

--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -136,7 +136,7 @@ jobs:
           kustomize edit set image ${CURRENT_NOTEBOOK_IMG}=${PR_NOTEBOOK_IMG}
 
           # configure culler
-          cat <<EOF | oc apply -f -
+          cat <<EOF | kubectl apply -f -
           ---
           apiVersion: v1
           kind: ConfigMap
@@ -169,7 +169,7 @@ jobs:
 
           echo "odh-notebook-controller-image=localhost/${{env.IMG}}:${{env.TAG}}" > params.env
 
-          cat <<EOF | oc apply -f -
+          cat <<EOF | kubectl apply -f -
           ---
           apiVersion: v1
           kind: ConfigMap
@@ -225,7 +225,7 @@ jobs:
       - name: Create notebook and check it, this is from kubeflow readme
         run: |
           notebook_namespace=default
-          cat <<EOF | oc apply -f -
+          cat <<EOF | kubectl apply -f -
           ---
           apiVersion: kubeflow.org/v1
           kind: Notebook


### PR DESCRIPTION
* https://github.com/opendatahub-io/kubeflow/pull/417

We don't have `oc` preinstalled on the new GitHub Actions runners that we were autoupdated to. Best to stick to kubectl.