### PR TITLE
Sync kustomization.yaml namespace with what we have in upstream

### DIFF
--- a/components/notebook-controller/config/overlays/openshift/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/openshift/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+namespace: opendatahub
 commonLabels:
   app.kubernetes.io/part-of: odh-notebook-controller
   component.opendatahub.io/name: kf-notebook-controller


### PR DESCRIPTION
The odh/rhoai operator overrides the namespace values anyway, so we should be okay. With this in sync with upstream, we reduce the code difference and will able the e2e tests to work as are defined now.

We may want to rethink the e2e test env preparation in the future eventually.