### PR TITLE
fix(params.env): missing oauth-proxy data for kustomization input

### DIFF
--- a/components/odh-notebook-controller/config/base/params.env
+++ b/components/odh-notebook-controller/config/base/params.env
@@ -1,1 +1,2 @@
 odh-notebook-controller-image=quay.io/opendatahub/odh-notebook-controller:v1.10.0-4
+oauth-proxy-image=registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5


### PR DESCRIPTION
This got lost during the [upstream->downstream sync](https://github.com/red-hat-data-services/rhods-devops-infra/actions/runs/17092008466/job/48467628771) yesterday.

Using the data we have in ODH, see opendatahub-io/kubeflow#671.