### PR TITLE
[rhoai-2.22.2][RHOAIENG-31063] Bump oauth image

### DIFF
--- a/.github/workflows/odh_notebook_controller_integration_test.yaml
+++ b/.github/workflows/odh_notebook_controller_integration_test.yaml
@@ -227,7 +227,7 @@ jobs:
           # switching to unauthenticated oauth-proxy image, c.f. https://github.com/opendatahub-io/opendatahub-community/issues/100
           kustomize build . | \
             sed 's/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/g' | \
-            sed 's|registry.redhat.io/openshift4/ose-oauth-proxy.*|quay.io/openshift/origin-oauth-proxy@sha256:1ece77d14a685ef2397c3a327844eea45ded00c95471e9e333e35ef3860b1895|g' | \
+            sed 's|registry.redhat.io/openshift4/ose-oauth-proxy.*|quay.io/openshift/origin-oauth-proxy:4.19|g' | \
             kubectl apply -f -
 
           # patch the webhook with our self-signed CA

--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: Always
           command:
             - /manager
-          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695"]
+          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"]
           securityContext:
             allowPrivilegeEscalation: false
           ports:

--- a/components/odh-notebook-controller/config/manager/manager.yaml
+++ b/components/odh-notebook-controller/config/manager/manager.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: Always
           command:
             - /manager
-          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"]
+          args: ["--oauth-proxy-image", "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415"]
           securityContext:
             allowPrivilegeEscalation: false
           ports:

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -42,9 +42,9 @@ const (
 	OAuthServicePort     = 443
 	OAuthServicePortName = "oauth-proxy"
 	// OAuthProxyImage uses sha256 manifest list digest value of v4.14 image for AMD64 as default to be compatible with imagePullPolicy: IfNotPresent, overridable
-	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64?image=66cefc14401df6ff4664ec43&architecture=amd64&container-tabs=overview
+	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy-rhel9/652809b7ad45c632d2163eed?container-tabs=overview&image=6889112836269c65855c1573
 	// and kept in sync with the manifests here and in ClusterServiceVersion metadata of opendatahub operator
-	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695"
+	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"
 
 	// Strings used in secret generation
 	letterRunes = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -41,7 +41,7 @@ import (
 const (
 	OAuthServicePort     = 443
 	OAuthServicePortName = "oauth-proxy"
-	// OAuthProxyImage uses sha256 manifest list digest value of v4.14 image for AMD64 as default to be compatible with imagePullPolicy: IfNotPresent, overridable
+	// OAuthProxyImage uses sha256 manifest list digest value of v4.19 image as default to be compatible with imagePullPolicy: IfNotPresent, overridable
 	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy-rhel9/652809b7ad45c632d2163eed?container-tabs=overview&image=6889112836269c65855c1573
 	// and kept in sync with the manifests here and in ClusterServiceVersion metadata of opendatahub operator
 	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"

--- a/components/odh-notebook-controller/controllers/notebook_oauth.go
+++ b/components/odh-notebook-controller/controllers/notebook_oauth.go
@@ -42,9 +42,9 @@ const (
 	OAuthServicePort     = 443
 	OAuthServicePortName = "oauth-proxy"
 	// OAuthProxyImage uses sha256 manifest list digest value of v4.19 image as default to be compatible with imagePullPolicy: IfNotPresent, overridable
-	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy-rhel9/652809b7ad45c632d2163eed?container-tabs=overview&image=6889112836269c65855c1573
+	// taken from https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy-rhel9/652809b7ad45c632d2163eed?container-tabs=overview&image=68a4c560e5f735b29eba5f29
 	// and kept in sync with the manifests here and in ClusterServiceVersion metadata of opendatahub operator
-	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5"
+	OAuthProxyImage = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415"
 
 	// Strings used in secret generation
 	letterRunes = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"


### PR DESCRIPTION
* https://issues.redhat.com/browse/RHOAIENG-31063

Open question - what is the proper branch target? Is it rhoai-2.22 or rhoai-2.22.2 which also exists? I don't recall we had separate branch for patch release in the past :thinking: Looks like rhoai-2.22.2 should be it, but it contains some extra and unexpected commits...
* the answer is to use the `rhoai-2.22` as usual

Also, I may squash all commits into one (mainly since the first commit is irrelevant as I update to the latest image available anyway?