### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-notebook-controller-v2-21

### DIFF
--- a/components/odh-notebook-controller/Dockerfile.konflux
+++ b/components/odh-notebook-controller/Dockerfile.konflux
@@ -41,7 +41,8 @@ USER 1001:0
 ENTRYPOINT [ "/manager" ]
 
 LABEL com.redhat.component="odh-kf-notebook-controller-container" \
-      name="managed-open-data-hub/odh-kf-notebook-controller-rhel8" \
+      name="rhoai/odh-notebook-controller-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.21::el9" \
       description="odh-kf-notebook-controller" \
       summary="odh-kf-notebook-controller" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
