### PR TITLE
fix(Dockerfile.konflux): update the labels to use correct naming

### DIFF
--- a/components/notebook-controller/Dockerfile.konflux
+++ b/components/notebook-controller/Dockerfile.konflux
@@ -22,7 +22,7 @@ COPY ${SOURCE_CODE}/common ./common
 # Update building workdir
 WORKDIR /opt/rhods/notebook-controller
 
-## Build the odh-notebook-controller
+## Build the odh-kf-notebook-controller
 USER root
 
 # Build
@@ -46,12 +46,12 @@ USER 1001:0
 
 ENTRYPOINT [ "/manager" ]
 
-LABEL com.redhat.component="odh-notebook-controller-container" \
-      name="managed-open-data-hub/odh-notebook-controller-rhel8" \
-      description="odh-notebook-controller" \
-      summary="odh-notebook-controller" \
+LABEL com.redhat.component="odh-kf-notebook-controller-container" \
+      name="rhoai/odh-kf-notebook-controller-rhel9" \
+      description="odh-kf-notebook-controller" \
+      summary="odh-kf-notebook-controller" \
       maintainer="['managed-open-data-hub@redhat.com']" \
       io.openshift.expose-services="" \
-      io.k8s.display-name="odh-notebook-controller" \
-      io.k8s.description="odh-notebook-controller" \
+      io.k8s.display-name="odh-kf-notebook-controller" \
+      io.k8s.description="odh-kf-notebook-controller" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/components/odh-notebook-controller/Dockerfile.konflux
+++ b/components/odh-notebook-controller/Dockerfile.konflux
@@ -40,12 +40,12 @@ USER 1001:0
 
 ENTRYPOINT [ "/manager" ]
 
-LABEL com.redhat.component="odh-kf-notebook-controller-container" \
-      name="managed-open-data-hub/odh-kf-notebook-controller-rhel8" \
-      description="odh-kf-notebook-controller" \
-      summary="odh-kf-notebook-controller" \
+LABEL com.redhat.component="odh-notebook-controller-container" \
+      name="rhoai/odh-notebook-controller-rhel9" \
+      description="odh-notebook-controller" \
+      summary="odh-notebook-controller" \
       maintainer="['managed-open-data-hub@redhat.com']" \
       io.openshift.expose-services="" \
-      io.k8s.display-name="odh-kf-notebook-controller" \
-      io.k8s.description="odh-kf-notebook-controller" \
+      io.k8s.display-name="odh-notebook-controller" \
+      io.k8s.description="odh-notebook-controller" \
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"


### PR DESCRIPTION
This fixes the labels for the odh-kf-notebook-controller and odh-notebook-controller as they were used in exactly opposite way.

I also updated the name to conform the konflux artifact.

The name update is inspired from #768 and #769 PRs.

I'm not adding a CPE label as I don't know what exactly to use.