### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-kf-notebook-controller-v2-19

### DIFF
--- a/components/notebook-controller/Dockerfile.konflux
+++ b/components/notebook-controller/Dockerfile.konflux
@@ -51,7 +51,8 @@ USER 1001:0
 ENTRYPOINT [ "/manager" ]
 
 LABEL com.redhat.component="odh-notebook-controller-container" \
-      name="managed-open-data-hub/odh-notebook-controller-rhel8" \
+      name="rhoai/odh-kf-notebook-controller-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.19::el8" \
       description="odh-notebook-controller" \
       summary="odh-notebook-controller" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
