### PR TITLE
Bump go-toolset images in Dockerfile.konflux from golang 1.25 to 1.26

### DIFF
--- a/components/notebook-controller/Dockerfile.konflux
+++ b/components/notebook-controller/Dockerfile.konflux
@@ -2,7 +2,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 as builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/components/odh-notebook-controller/Dockerfile.konflux
+++ b/components/odh-notebook-controller/Dockerfile.konflux
@@ -2,7 +2,7 @@
 ARG SOURCE_CODE=.
 
 # Use ubi9/go-toolset as base image
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26@sha256:d36470d5258da00f618b7aca9bdaab8e05134aa938bd6c42d9bd17d50ed45e76 as builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-65206
https://redhat.atlassian.net/browse/RHOAIENG-67027

## Summary
- Update the pinned `ubi9/go-toolset` image in both Konflux Dockerfiles from Go 1.25 to Go 1.26 (manifest list digest)
- This completes the Go version bump for RHOAI 3.5 (EUS release) in the downstream repo

## Changes
| File | Before | After |
|------|--------|-------|
| `components/notebook-controller/Dockerfile.konflux` | `go-toolset:1.25@sha256:90a36bc...` | `go-toolset:1.26@sha256:d36470d...` |
| `components/odh-notebook-controller/Dockerfile.konflux` | `go-toolset:1.25@sha256:90a36bc...` | `go-toolset:1.26@sha256:d36470d...` |

The sha256 digest used is the **Manifest List Digest** (multi-arch) for `registry.access.redhat.com/ubi9/go-toolset:1.26` from the Red Hat container catalog.

## Context
- Upstream Go bump PR already merged in opendatahub-io/kubeflow
- All other downstream files (Dockerfiles, go.mod, workflows, pre-commit) are already synced
- Only the Konflux Dockerfiles remained with the old Go 1.25 pinned image