### PR TITLE
[3.3.z] RHOAIENG-60592: Update workbench fails with "Workbench admission webhook error"

### DIFF
--- a/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_secret.go
@@ -218,10 +218,22 @@ func extractElyraRuntimeConfigInfo(ctx context.Context, gatewayInstance map[stri
 	// Extract API Endpoint from DSPA status
 	apiEndpoint := dspaInstance.Status.Components.APIServer.ExternalUrl
 
-	// Extract info from DSPA spec
+	// Extract info from DSPA spec.
+	// ObjectStorage, ExternalStorage, and S3CredentialSecret are embedded pointer
+	// fields in the DSPA API types (e.g. *ObjectStorage, *ExternalStorage,
+	// *S3CredentialSecret). Although the CRD schema marks them as required, a
+	// partially-configured or transitional DSPA CR can still have these as nil at
+	// the Go struct level, causing a nil pointer dereference panic if unchecked.
 	spec := dspaInstance.Spec
 	objectStorage := spec.ObjectStorage
+	if objectStorage == nil {
+		return nil, fmt.Errorf("invalid DSPA CR: 'objectStorage' is not configured")
+	}
+
 	externalStorage := objectStorage.ExternalStorage
+	if externalStorage == nil {
+		return nil, fmt.Errorf("invalid DSPA CR: 'objectStorage.externalStorage' is not configured")
+	}
 
 	// Validate required fields
 	host := externalStorage.Host
@@ -242,9 +254,22 @@ func extractElyraRuntimeConfigInfo(ctx context.Context, gatewayInstance map[stri
 	}
 
 	s3CredentialsSecret := externalStorage.S3CredentialSecret
+	if s3CredentialsSecret == nil {
+		return nil, fmt.Errorf("invalid DSPA CR: 'objectStorage.externalStorage.s3CredentialSecret' is not configured")
+	}
+
 	cosSecret := s3CredentialsSecret.SecretName
+	if cosSecret == "" {
+		return nil, fmt.Errorf("invalid DSPA CR: 'objectStorage.externalStorage.s3CredentialSecret.secretName' is empty")
+	}
 	usernameKey := s3CredentialsSecret.AccessKey
+	if usernameKey == "" {
+		return nil, fmt.Errorf("invalid DSPA CR: 'objectStorage.externalStorage.s3CredentialSecret.accessKey' is empty")
+	}
 	passwordKey := s3CredentialsSecret.SecretKey
+	if passwordKey == "" {
+		return nil, fmt.Errorf("invalid DSPA CR: 'objectStorage.externalStorage.s3CredentialSecret.secretKey' is empty")
+	}
 
 	// Fetch secret containing credentials
 	dspaCOSSecret := &corev1.Secret{}
@@ -334,8 +359,11 @@ func SyncElyraRuntimeConfigSecret(ctx context.Context, cli client.Client, config
 	// Generate DSPA-based Elyra config
 	dspData, err := extractElyraRuntimeConfigInfo(ctx, gatewayInstance, dspaInstance, cli, notebook, log)
 	if err != nil {
-		log.Error(err, "Failed to extract Elyra runtime config info")
-		return err
+		// Treat a misconfigured/incomplete DSPA the same as a missing one: log a
+		// warning and skip. The Elyra integration is supplemental and must not
+		// block notebook creation or reconciliation.
+		log.Info("DSPA CR is incomplete, skipping Elyra secret creation", "namespace", notebook.Namespace, "reason", err.Error())
+		return nil
 	}
 	if dspData == nil {
 		return nil

--- a/components/odh-notebook-controller/controllers/notebook_dspa_secret_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_dspa_secret_test.go
@@ -587,6 +587,166 @@ var _ = Describe("extractElyraRuntimeConfigInfo", func() {
 		return dspa
 	}
 
+	Context("when DSPA nested fields are nil", func() {
+		It("should return error when ObjectStorage is nil", func() {
+			dspa := &dspav1.DataSciencePipelinesApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dspa",
+					Namespace: "test-namespace",
+				},
+				Spec: dspav1.DSPASpec{
+					ObjectStorage: nil,
+				},
+			}
+			notebook := createTestNotebook("notebook", "test-namespace")
+
+			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+			result, err := extractElyraRuntimeConfigInfo(testCtx, nil, dspa, fakeClient, notebook, log)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'objectStorage' is not configured"))
+			Expect(result).To(BeNil())
+		})
+
+		It("should return error when ExternalStorage is nil", func() {
+			dspa := &dspav1.DataSciencePipelinesApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dspa",
+					Namespace: "test-namespace",
+				},
+				Spec: dspav1.DSPASpec{
+					ObjectStorage: &dspav1.ObjectStorage{
+						ExternalStorage: nil,
+					},
+				},
+			}
+			notebook := createTestNotebook("notebook", "test-namespace")
+
+			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+			result, err := extractElyraRuntimeConfigInfo(testCtx, nil, dspa, fakeClient, notebook, log)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'objectStorage.externalStorage' is not configured"))
+			Expect(result).To(BeNil())
+		})
+
+		It("should return error when S3CredentialSecret is nil", func() {
+			dspa := &dspav1.DataSciencePipelinesApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dspa",
+					Namespace: "test-namespace",
+				},
+				Spec: dspav1.DSPASpec{
+					ObjectStorage: &dspav1.ObjectStorage{
+						ExternalStorage: &dspav1.ExternalStorage{
+							Host:               "minio.example.com",
+							Bucket:             "my-bucket",
+							S3CredentialSecret: nil,
+						},
+					},
+				},
+			}
+			notebook := createTestNotebook("notebook", "test-namespace")
+
+			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+			result, err := extractElyraRuntimeConfigInfo(testCtx, nil, dspa, fakeClient, notebook, log)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'objectStorage.externalStorage.s3CredentialSecret' is not configured"))
+			Expect(result).To(BeNil())
+		})
+
+		It("should return error when S3CredentialSecret.SecretName is empty", func() {
+			dspa := &dspav1.DataSciencePipelinesApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dspa",
+					Namespace: "test-namespace",
+				},
+				Spec: dspav1.DSPASpec{
+					ObjectStorage: &dspav1.ObjectStorage{
+						ExternalStorage: &dspav1.ExternalStorage{
+							Host:   "minio.example.com",
+							Bucket: "my-bucket",
+							S3CredentialSecret: &dspav1.S3CredentialSecret{
+								SecretName: "",
+								AccessKey:  "accesskey",
+								SecretKey:  "secretkey",
+							},
+						},
+					},
+				},
+			}
+			notebook := createTestNotebook("notebook", "test-namespace")
+
+			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+			result, err := extractElyraRuntimeConfigInfo(testCtx, nil, dspa, fakeClient, notebook, log)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'objectStorage.externalStorage.s3CredentialSecret.secretName' is empty"))
+			Expect(result).To(BeNil())
+		})
+
+		It("should return error when S3CredentialSecret.AccessKey is empty", func() {
+			dspa := &dspav1.DataSciencePipelinesApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dspa",
+					Namespace: "test-namespace",
+				},
+				Spec: dspav1.DSPASpec{
+					ObjectStorage: &dspav1.ObjectStorage{
+						ExternalStorage: &dspav1.ExternalStorage{
+							Host:   "minio.example.com",
+							Bucket: "my-bucket",
+							S3CredentialSecret: &dspav1.S3CredentialSecret{
+								SecretName: "my-secret",
+								AccessKey:  "",
+								SecretKey:  "secretkey",
+							},
+						},
+					},
+				},
+			}
+			notebook := createTestNotebook("notebook", "test-namespace")
+
+			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+			result, err := extractElyraRuntimeConfigInfo(testCtx, nil, dspa, fakeClient, notebook, log)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'objectStorage.externalStorage.s3CredentialSecret.accessKey' is empty"))
+			Expect(result).To(BeNil())
+		})
+
+		It("should return error when S3CredentialSecret.SecretKey is empty", func() {
+			dspa := &dspav1.DataSciencePipelinesApplication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dspa",
+					Namespace: "test-namespace",
+				},
+				Spec: dspav1.DSPASpec{
+					ObjectStorage: &dspav1.ObjectStorage{
+						ExternalStorage: &dspav1.ExternalStorage{
+							Host:   "minio.example.com",
+							Bucket: "my-bucket",
+							S3CredentialSecret: &dspav1.S3CredentialSecret{
+								SecretName: "my-secret",
+								AccessKey:  "accesskey",
+								SecretKey:  "",
+							},
+						},
+					},
+				},
+			}
+			notebook := createTestNotebook("notebook", "test-namespace")
+
+			fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+			result, err := extractElyraRuntimeConfigInfo(testCtx, nil, dspa, fakeClient, notebook, log)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("'objectStorage.externalStorage.s3CredentialSecret.secretKey' is empty"))
+			Expect(result).To(BeNil())
+		})
+	})
+
 	It("should return error when DSPA host is empty", func() {
 		dspa := createTestDSPA("", "my-bucket", "cos-secret", "accesskey", "secretkey", "")
 		notebook := createTestNotebook("notebook", "test-namespace")
@@ -884,5 +1044,109 @@ var _ = Describe("extractElyraRuntimeConfigInfo", func() {
 		Expect(metadata["cos_username"]).To(Equal("myaccesskey"))
 		Expect(metadata["cos_password"]).To(Equal("mysecretkey"))
 		Expect(metadata["cos_secret"]).To(Equal("cos-secret"))
+	})
+})
+
+var _ = Describe("SyncElyraRuntimeConfigSecret", func() {
+	var (
+		testCtx    context.Context
+		testScheme *runtime.Scheme
+		log        = ctrl.Log.WithName("test")
+	)
+
+	BeforeEach(func() {
+		testCtx = context.Background()
+		testScheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(testScheme)).To(Succeed())
+		Expect(routev1.AddToScheme(testScheme)).To(Succeed())
+		Expect(dspav1.AddToScheme(testScheme)).To(Succeed())
+		Expect(gatewayv1.Install(testScheme)).To(Succeed())
+	})
+
+	It("should skip gracefully when DSPA CR does not exist", func() {
+		notebook := &nbv1.Notebook{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "notebook",
+				Namespace: "test-namespace",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+		err := SyncElyraRuntimeConfigSecret(testCtx, fakeClient, notebook, log)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should skip gracefully without panic when DSPA has nil ObjectStorage", func() {
+		dspa := &dspav1.DataSciencePipelinesApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dspa",
+				Namespace: "test-namespace",
+			},
+			Spec: dspav1.DSPASpec{
+				ObjectStorage: nil,
+			},
+		}
+		notebook := &nbv1.Notebook{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "notebook",
+				Namespace: "test-namespace",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(dspa).Build()
+
+		err := SyncElyraRuntimeConfigSecret(testCtx, fakeClient, notebook, log)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should skip gracefully without panic when DSPA has nil ExternalStorage", func() {
+		dspa := &dspav1.DataSciencePipelinesApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dspa",
+				Namespace: "test-namespace",
+			},
+			Spec: dspav1.DSPASpec{
+				ObjectStorage: &dspav1.ObjectStorage{
+					ExternalStorage: nil,
+				},
+			},
+		}
+		notebook := &nbv1.Notebook{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "notebook",
+				Namespace: "test-namespace",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(dspa).Build()
+
+		err := SyncElyraRuntimeConfigSecret(testCtx, fakeClient, notebook, log)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should skip gracefully without panic when DSPA has nil S3CredentialSecret", func() {
+		dspa := &dspav1.DataSciencePipelinesApplication{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dspa",
+				Namespace: "test-namespace",
+			},
+			Spec: dspav1.DSPASpec{
+				ObjectStorage: &dspav1.ObjectStorage{
+					ExternalStorage: &dspav1.ExternalStorage{
+						Host:               "minio.example.com",
+						Bucket:             "my-bucket",
+						S3CredentialSecret: nil,
+					},
+				},
+			},
+		}
+		notebook := &nbv1.Notebook{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "notebook",
+				Namespace: "test-namespace",
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(dspa).Build()
+
+		err := SyncElyraRuntimeConfigSecret(testCtx, fakeClient, notebook, log)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/RHOAIENG-37059.

Backport of the #1586.

Alternative that includes also typed clients change backport is #1587.

---

* [RHOAIENG-60592](https://redhat.atlassian.net/browse/RHOAIENG-60592): Add nil guards in extractElyraRuntimeConfigInfo to prevent panic

When a DSPA CR exists in a namespace but has nil pointer fields (ObjectStorage, ExternalStorage, or S3CredentialSecret), the controller crashes with a nil pointer dereference during every Notebook reconcile and webhook call, causing a crash loop that blocks all workbench updates in that namespace. This adds nil checks before dereferencing these pointer fields so the controller returns a clear error instead of panicking.

Closes [RHOAIENG-60592](https://redhat.atlassian.net/browse/RHOAIENG-60592)




* [RHOAIENG-60592](https://redhat.atlassian.net/browse/RHOAIENG-60592): Align nil guard error messages with PR #743 and add SecretName validation

Improves the nil guard error messages to use fully-qualified dot-path field notation (e.g. 'objectStorage.externalStorage') and 'is not configured' wording consistent with the maintainer's preferred style. Adds a missing validation for empty S3CredentialSecret.SecretName. Restructures tests under a Context block for better organization and adds a test case for the new SecretName validation.

Closes [RHOAIENG-60592](https://redhat.atlassian.net/browse/RHOAIENG-60592)




* [RHOAIENG-60592](https://redhat.atlassian.net/browse/RHOAIENG-60592): Add empty-string validation for AccessKey and SecretKey fields

Add consistent validation for all S3CredentialSecret string fields (AccessKey and SecretKey) to match the existing SecretName validation, as requested in PR review feedback for consistency across all required fields.

Closes [RHOAIENG-60592](https://redhat.atlassian.net/browse/RHOAIENG-60592)




* small polishing and added couple of test cases for actual reconciliation

* treat misconfigured dspa gracefully

---------





(cherry picked from commit 62ebba193e4f95dc48facc8a621d741494cd19af) (cherry picked from commit 39fe9c1117b82f3dbfea24ab42c21b8d077906de)