### PR TITLE
[3.5] fix: reduce kube-rbac-proxy log verbosity from v=10 to v=0

### DIFF
--- a/components/notebook-controller/config/default/manager_auth_proxy_patch.yaml
+++ b/components/notebook-controller/config/default/manager_auth_proxy_patch.yaml
@@ -15,7 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=0"
         ports:
         - containerPort: 8443
           name: https

--- a/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_mutating_webhook.go
@@ -210,7 +210,7 @@ func InjectKubeRbacProxy(notebook *nbv1.Notebook, kubeRbacProxyConfig KubeRbacPr
 			"--secure-listen-address=0.0.0.0:" + strconv.Itoa(NotebookKubeRbacProxyPort),
 			"--upstream=http://127.0.0.1:" + strconv.Itoa(NotebookPort) + "/",
 			"--logtostderr=true",
-			"--v=10", // TODO - TBD, this is too verbose
+			"--v=0",
 			"--proxy-endpoints-port=" + strconv.Itoa(NotebookKubeRbacProxyHealthPort),
 			"--config-file=" + KubeRbacProxyConfigFilePath,
 			"--tls-cert-file=" + KubeRbacProxyTLSCertFilePath,


### PR DESCRIPTION
The kube-rbac-proxy sidecar was hardcoded with --v=10, which is far too verbose for production use and generates excessive log volume. Lower it to --v=0 (the klog default), which still logs errors, warnings, and essential info while suppressing debug-level output.

Resolves an in-code TODO that acknowledged the verbosity was too high.

https://redhat.atlassian.net/browse/RHOAIENG-69555