### PR TITLE
[3.5] Reject dangerous PodSpec fields in notebook validating webhook.

### DIFF
--- a/components/odh-notebook-controller/config/webhook/manifests.yaml
+++ b/components/odh-notebook-controller/config/webhook/manifests.yaml
@@ -45,6 +45,7 @@ webhooks:
     apiVersions:
     - v1
     operations:
+    - CREATE
     - UPDATE
     resources:
     - notebooks

--- a/components/odh-notebook-controller/controllers/notebook_podspec_validation.go
+++ b/components/odh-notebook-controller/controllers/notebook_podspec_validation.go
@@ -1,0 +1,72 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func validatePodSpecSecurity(podSpec *corev1.PodSpec, notebookName string) error {
+	if podSpec == nil {
+		return nil
+	}
+
+	if podSpec.HostNetwork {
+		return fmt.Errorf("hostNetwork is not allowed in notebook pod spec")
+	}
+	if podSpec.HostPID {
+		return fmt.Errorf("hostPID is not allowed in notebook pod spec")
+	}
+	if podSpec.HostIPC {
+		return fmt.Errorf("hostIPC is not allowed in notebook pod spec")
+	}
+
+	if podSpec.ServiceAccountName != "" && podSpec.ServiceAccountName != notebookName {
+		return fmt.Errorf("serviceAccountName %q is not allowed; notebooks use a dedicated service account named after the notebook", podSpec.ServiceAccountName)
+	}
+
+	for _, volume := range podSpec.Volumes {
+		if volume.VolumeSource.HostPath != nil {
+			return fmt.Errorf("hostPath volume %q is not allowed in notebook pod spec", volume.Name)
+		}
+	}
+
+	for _, container := range podSpec.Containers {
+		if err := validateContainerSecurityContext(container.Name, container.SecurityContext); err != nil {
+			return err
+		}
+	}
+	for _, container := range podSpec.InitContainers {
+		if err := validateContainerSecurityContext(container.Name, container.SecurityContext); err != nil {
+			return err
+		}
+	}
+	for _, container := range podSpec.EphemeralContainers {
+		if err := validateContainerSecurityContext(container.Name, container.SecurityContext); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateContainerSecurityContext(containerName string, securityContext *corev1.SecurityContext) error {
+	if securityContext != nil && securityContext.Privileged != nil && *securityContext.Privileged {
+		return fmt.Errorf("privileged container %q is not allowed in notebook pod spec", containerName)
+	}
+	return nil
+}

--- a/components/odh-notebook-controller/controllers/notebook_podspec_validation_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_podspec_validation_test.go
@@ -1,0 +1,110 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("validatePodSpecSecurity", func() {
+	basePodSpec := func() *corev1.PodSpec {
+		return &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "test",
+				Image: "test-image:latest",
+			}},
+		}
+	}
+
+	It("allows a minimal valid pod spec", func() {
+		Expect(validatePodSpecSecurity(basePodSpec(), "test-notebook")).To(Succeed())
+	})
+
+	It("allows a pod spec with the notebook service account", func() {
+		podSpec := basePodSpec()
+		podSpec.ServiceAccountName = "my-notebook"
+		Expect(validatePodSpecSecurity(podSpec, "my-notebook")).To(Succeed())
+	})
+
+	It("rejects hostNetwork", func() {
+		podSpec := basePodSpec()
+		podSpec.HostNetwork = true
+		err := validatePodSpecSecurity(podSpec, "my-notebook")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("hostNetwork"))
+	})
+
+	It("rejects hostPID", func() {
+		podSpec := basePodSpec()
+		podSpec.HostPID = true
+		err := validatePodSpecSecurity(podSpec, "my-notebook")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("hostPID"))
+	})
+
+	It("rejects hostIPC", func() {
+		podSpec := basePodSpec()
+		podSpec.HostIPC = true
+		err := validatePodSpecSecurity(podSpec, "my-notebook")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("hostIPC"))
+	})
+
+	It("rejects hostPath volumes", func() {
+		podSpec := basePodSpec()
+		podSpec.Volumes = []corev1.Volume{{
+			Name: "host",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{Path: "/etc"},
+			},
+		}}
+		err := validatePodSpecSecurity(podSpec, "my-notebook")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("hostPath volume"))
+	})
+
+	It("rejects privileged containers", func() {
+		podSpec := basePodSpec()
+		podSpec.Containers[0].SecurityContext = &corev1.SecurityContext{Privileged: ptr.To(true)}
+		err := validatePodSpecSecurity(podSpec, "my-notebook")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("privileged container"))
+	})
+
+	It("rejects privileged init containers", func() {
+		podSpec := basePodSpec()
+		podSpec.InitContainers = []corev1.Container{{
+			Name:  "init",
+			Image: "init-image:latest",
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: ptr.To(true),
+			},
+		}}
+		err := validatePodSpecSecurity(podSpec, "my-notebook")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("privileged container"))
+	})
+
+	It("rejects arbitrary service accounts", func() {
+		podSpec := basePodSpec()
+		podSpec.ServiceAccountName = "admin"
+		err := validatePodSpecSecurity(podSpec, "my-notebook")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("serviceAccountName"))
+	})
+})

--- a/components/odh-notebook-controller/controllers/notebook_validating_webhook.go
+++ b/components/odh-notebook-controller/controllers/notebook_validating_webhook.go
@@ -28,39 +28,37 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-//+kubebuilder:webhook:path=/validate-notebook-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=notebooks,verbs=update,versions=v1,name=notebooks-validation.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-notebook-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=notebooks,verbs=create;update,versions=v1,name=notebooks-validation.opendatahub.io,admissionReviewVersions=v1
 
-// NotebookValidatingWebhook validates Notebook updates
+// NotebookValidatingWebhook validates Notebook create and update requests.
 type NotebookValidatingWebhook struct {
 	Log     logr.Logger
 	Client  client.Client
 	Decoder admission.Decoder
 }
 
-// Handle validates Notebook updates
+// Handle validates Notebook create and update requests.
 func (v *NotebookValidatingWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
 	log := v.Log.WithValues("notebook", req.Name, "namespace", req.Namespace)
 
-	// Only validate updates
-	if req.Operation != admissionv1.Update {
-		return admission.Allowed("")
-	}
-
-	// Decode the new notebook
 	newNotebook := &nbv1.Notebook{}
 	if err := v.Decoder.Decode(req, newNotebook); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	// Decode the old notebook
-	oldNotebook := &nbv1.Notebook{}
-	if err := v.Decoder.DecodeRaw(req.OldObject, oldNotebook); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
+	if err := validatePodSpecSecurity(&newNotebook.Spec.Template.Spec, newNotebook.Name); err != nil {
+		return admission.Denied(err.Error())
 	}
 
-	// Check if MLflow annotation is being removed
-	if err := v.validateMLflowAnnotationRemoval(oldNotebook, newNotebook, log); err != nil {
-		return admission.Denied(err.Error())
+	if req.Operation == admissionv1.Update {
+		oldNotebook := &nbv1.Notebook{}
+		if err := v.Decoder.DecodeRaw(req.OldObject, oldNotebook); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if err := v.validateMLflowAnnotationRemoval(oldNotebook, newNotebook, log); err != nil {
+			return admission.Denied(err.Error())
+		}
 	}
 
 	return admission.Allowed("")

--- a/components/odh-notebook-controller/controllers/notebook_validating_webhook_test.go
+++ b/components/odh-notebook-controller/controllers/notebook_validating_webhook_test.go
@@ -24,15 +24,34 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("The Openshift Notebook validating webhook", func() {
-	When("Updating a Notebook's MLflow annotation", func() {
-		const (
-			Namespace = "default"
-		)
+	const Namespace = "default"
 
+	updateNotebookWithRetry := func(name string, updateFn func(*nbv1.Notebook)) error {
+		var lastErr error
+		for i := 0; i < 10; i++ {
+			notebook := &nbv1.Notebook{}
+			if err := cli.Get(ctx, types.NamespacedName{Name: name, Namespace: Namespace}, notebook); err != nil {
+				return err
+			}
+			updateFn(notebook)
+			lastErr = cli.Update(ctx, notebook)
+			if lastErr == nil {
+				return nil
+			}
+			if !apierrs.IsConflict(lastErr) {
+				return lastErr
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		return lastErr
+	}
+
+	When("Updating a Notebook's MLflow annotation", func() {
 		BeforeEach(func() {
 			// Ensure namespace exists
 			err := cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: Namespace}}, &client.CreateOptions{})
@@ -59,30 +78,6 @@ var _ = Describe("The Openshift Notebook validating webhook", func() {
 					},
 				},
 			}
-		}
-
-		// updateNotebookWithRetry fetches the latest notebook and applies the update function,
-		// retrying on conflict errors. Returns the final error (nil on success, or validation error).
-		updateNotebookWithRetry := func(name string, updateFn func(*nbv1.Notebook)) error {
-			var lastErr error
-			for i := 0; i < 10; i++ {
-				notebook := &nbv1.Notebook{}
-				if err := cli.Get(ctx, types.NamespacedName{Name: name, Namespace: Namespace}, notebook); err != nil {
-					return err
-				}
-				updateFn(notebook)
-				lastErr = cli.Update(ctx, notebook)
-				if lastErr == nil {
-					return nil
-				}
-				if !apierrs.IsConflict(lastErr) {
-					// Not a conflict error - could be validation rejection or other error
-					return lastErr
-				}
-				// Conflict error - retry
-				time.Sleep(100 * time.Millisecond)
-			}
-			return lastErr
 		}
 
 		It("Should allow removing MLflow annotation when notebook is stopped", func() {
@@ -230,5 +225,97 @@ var _ = Describe("The Openshift Notebook validating webhook", func() {
 			}, 10*time.Second).Should(Succeed())
 		})
 
+	})
+
+	When("Creating or updating a Notebook with dangerous pod spec fields", func() {
+		BeforeEach(func() {
+			err := cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: Namespace}}, &client.CreateOptions{})
+			if err != nil && !apierrs.IsAlreadyExists(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		newNotebook := func(name string, mutate func(*corev1.PodSpec)) *nbv1.Notebook {
+			podSpec := corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  name,
+					Image: "test-image:latest",
+				}},
+			}
+			if mutate != nil {
+				mutate(&podSpec)
+			}
+			return &nbv1.Notebook{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: Namespace,
+				},
+				Spec: nbv1.NotebookSpec{
+					Template: nbv1.NotebookTemplateSpec{
+						Spec: podSpec,
+					},
+				},
+			}
+		}
+
+		It("Should deny create requests with hostNetwork", func() {
+			err := cli.Create(ctx, newNotebook("test-dangerous-create-hostnetwork", func(podSpec *corev1.PodSpec) {
+				podSpec.HostNetwork = true
+			}))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("hostNetwork"))
+		})
+
+		It("Should deny create requests with hostPath volumes", func() {
+			err := cli.Create(ctx, newNotebook("test-dangerous-create-hostpath", func(podSpec *corev1.PodSpec) {
+				podSpec.Volumes = []corev1.Volume{{
+					Name: "host",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{Path: "/etc"},
+					},
+				}}
+			}))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("hostPath volume"))
+		})
+
+		It("Should deny create requests with privileged containers", func() {
+			err := cli.Create(ctx, newNotebook("test-dangerous-create-privileged", func(podSpec *corev1.PodSpec) {
+				podSpec.Containers[0].SecurityContext = &corev1.SecurityContext{Privileged: ptr.To(true)}
+			}))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("privileged container"))
+		})
+
+		It("Should deny create requests with arbitrary service accounts", func() {
+			err := cli.Create(ctx, newNotebook("test-dangerous-create-serviceaccount", func(podSpec *corev1.PodSpec) {
+				podSpec.ServiceAccountName = "admin"
+			}))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("serviceAccountName"))
+		})
+
+		It("Should deny update requests that introduce dangerous pod spec fields", func() {
+			name := "test-dangerous-update"
+			notebook := newNotebook(name, nil)
+			Expect(cli.Create(ctx, notebook)).To(Succeed())
+
+			err := updateNotebookWithRetry(name, func(nb *nbv1.Notebook) {
+				nb.Spec.Template.Spec.HostNetwork = true
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("hostNetwork"))
+
+			Eventually(func() error {
+				nb := &nbv1.Notebook{}
+				if err := cli.Get(ctx, types.NamespacedName{Name: name, Namespace: Namespace}, nb); err != nil {
+					if apierrs.IsNotFound(err) {
+						return nil
+					}
+					return err
+				}
+				return cli.Delete(ctx, nb)
+			}, 10*time.Second).Should(Succeed())
+		})
 	})
 })


### PR DESCRIPTION
Notebook CRs embed a full PodSpec that the controller copies into StatefulSet pods, but admission only checked MLflow annotation removal on updates. Reject hostNetwork, hostPID, hostIPC, hostPath, privileged containers, and arbitrary service accounts on create and update.

https://redhat.atlassian.net/browse/RHOAIENG-69554
